### PR TITLE
synchronous connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "conch-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conch-runtime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vt6 0.0.1",
 ]
 
 [[package]]
@@ -712,6 +713,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vt6"
+version = "0.0.1"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["lærling <laerling@posteo.de>"]
 conch-parser = "^0.1.0"
 conch-runtime = "^0.1.4"
 tokio-core = "^0.1.17"
+vt6 = { path = "../vt6.rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["lærling <laerling@posteo.de>"]
 conch-parser = "^0.1.0"
 conch-runtime = "^0.1.4"
 tokio-core = "^0.1.17"
-vt6 = { path = "../vt6.rs" }
+vt6 = { path = "../vt6.rs/vt6" }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -53,10 +53,11 @@ impl Connection {
 
     /// waits for a response (synchronously)
     pub fn send_and_receive(&mut self, msg: &str) -> (Message, usize) {
-        loop {
 
-            // send
-            self.stream.write_all(msg.as_bytes()).unwrap(); // TODO: Use vt6 messages
+        // send
+        self.stream.write_all(msg.as_bytes()).unwrap(); // TODO: Use vt6 messages
+
+        loop {
 
             // read from stream...
             self.stream.read(&mut self.buffer).ok();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *
+ * Copyright 2018 lærling <laerling@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *******************************************************************************/
+
+use std::env::vars;
+use std::io;
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::io::Error;
+use std::io::ErrorKind;
+
+/// Encapsulates the message connection to the VT6 server
+pub struct Connection {
+    stream: UnixStream,
+}
+
+impl Connection {
+
+    /// finds the vt6 socket and connects to it
+    pub fn new() -> Result<Connection, io::Error> {
+
+        if let Some(vt6_socket_var) = vars().find(|var| var.0 == "VT6") {
+            return Ok(Connection {
+                stream: UnixStream::connect(PathBuf::from(vt6_socket_var.1))?,
+            });
+        }
+
+        Err(Error::new(ErrorKind::NotFound, "VT6 server connection not found."))
+    }
+
+    pub fn send(&mut self, msg: &str) {
+        self.stream.write_all(msg.as_bytes()).unwrap();
+    }
+
+    pub fn read(&mut self) {
+        use std::io::Read;
+        let mut answer = String::with_capacity(24); // FIXME: Always read to message end, not into a buffer of fixed size
+        let read_bytes = self.stream.read_to_string(&mut answer).unwrap();
+        println!("Read {} bytes: {}", read_bytes, answer);
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -23,34 +23,58 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::io::Error;
 use std::io::ErrorKind;
+use vt6::common::core::msg::Message;
 
-/// Encapsulates the message connection to the VT6 server
+/// Encapsulates the server connection
 pub struct Connection {
     stream: UnixStream,
+    buffer: Vec<u8>,
 }
 
 impl Connection {
 
-    /// finds the vt6 socket and connects to it
+    /// finds the vt6 socket and connects to it, returning a new connection object
     pub fn new() -> Result<Connection, io::Error> {
 
         if let Some(vt6_socket_var) = vars().find(|var| var.0 == "VT6") {
             return Ok(Connection {
                 stream: UnixStream::connect(PathBuf::from(vt6_socket_var.1))?,
+                buffer: vec![0;1024],
             });
         }
 
         Err(Error::new(ErrorKind::NotFound, "VT6 server connection not found."))
     }
 
-    pub fn send(&mut self, msg: &str) {
-        self.stream.write_all(msg.as_bytes()).unwrap();
-    }
+    /// sends a message and waits for the response synchronously
+    pub fn send_and_receive(&mut self, msg: &str) {
 
-    pub fn read(&mut self) {
+        // send
+        // TODO: Use vt6 messages
+        self.stream.write_all(msg.as_bytes()).unwrap();
+
+        // receive
         use std::io::Read;
-        let mut answer = String::with_capacity(24); // FIXME: Always read to message end, not into a buffer of fixed size
-        let read_bytes = self.stream.read_to_string(&mut answer).unwrap();
-        println!("Read {} bytes: {}", read_bytes, answer);
+        let read_bytes: usize;
+        let read_result: (Message, usize);
+        loop {
+
+            // read from stream
+            match self.stream.read(self.buffer) {
+                Ok(amount) => read_bytes = amount,
+                Err(e) => panic!(e),
+            }
+
+            // try to parse and end reading as soon as parsing successful
+            match Message::parse(&self.buffer) {
+                Ok(result) => {
+                    read_result = result;
+                    break;
+                },
+                Err(_) => {}, // continue
+            }
+        }
+
+        println!("Read {} bytes: {:?}", read_bytes, read_result.0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,8 +84,7 @@ fn main() {
 
     // FIXME temp
     let mut con = connection::Connection::new().unwrap();
-    con.send("{3|4:want,4:core,1:1,}");
-    con.read();
+    con.send_and_receive("{3|4:want,4:core,1:1,}");
     std::process::exit(0);
 
     // evaluate command line argument

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@
 extern crate conch_parser;
 extern crate conch_runtime;
 extern crate tokio_core;
+extern crate vt6;
 
 use conch_parser::lexer::Lexer;
 use conch_parser::parse::DefaultParser;
@@ -31,6 +32,8 @@ use std::io;
 use std::option::Option;
 use tokio_core::reactor::Core;
 use std::process::exit;
+
+mod connection;
 
 fn repl<T: io::BufRead>(script: &mut T) -> io::Result<()> {
 
@@ -78,6 +81,12 @@ fn repl<T: io::BufRead>(script: &mut T) -> io::Result<()> {
 }
 
 fn main() {
+
+    // FIXME temp
+    let mut con = connection::Connection::new().unwrap();
+    con.send("{3|4:want,4:core,1:1,}");
+    con.read();
+    std::process::exit(0);
 
     // evaluate command line argument
     let eval_result = match env::args().nth(1) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,8 +84,8 @@ fn main() {
 
     // FIXME temp
     let mut con = connection::Connection::new().unwrap();
-    println!("{}", con.send_and_receive("{3|4:want,4:core,1:1,}").0);
-    println!("{}", con.send_and_receive("{3|4:want,4:LmAo,1:1,}").0);
+    println!("main: core: {}", con.send_and_receive("{3|4:want,4:core,1:1,}").0);
+    println!("main: LmAo: {}", con.send_and_receive("{3|4:want,4:LmAo,1:1,}").0);
     std::process::exit(0);
 
     // evaluate command line argument

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,8 @@ fn main() {
 
     // FIXME temp
     let mut con = connection::Connection::new().unwrap();
-    con.send_and_receive("{3|4:want,4:core,1:1,}");
+    println!("{}", con.send_and_receive("{3|4:want,4:core,1:1,}").0);
+    println!("{}", con.send_and_receive("{3|4:want,4:LmAo,1:1,}").0);
     std::process::exit(0);
 
     // evaluate command line argument


### PR DESCRIPTION
Like stated in #2, we don't need asynchronous messaging for now.
Though, there are still a few todos for synchronous messaging:
- [ ] Use `[u8]` instead of `[u8; 1024]`
- [ ] If the incoming message is `core.pub`, handle it before the originally expected message